### PR TITLE
fixed bug where null could be read as a non-scalar

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -246,6 +246,9 @@ function syncObject(toObj, fromObj, options = {}) {
 				return fromVal;
 			}
 			return unchangedSymbol;
+		} else if (isScalar(toVal) || isScalar(fromVal)) {
+			// Exactly one of the two is scalar; either way, overwrite the key on toVal
+			return fromVal;
 		} else if (Array.isArray(toVal) && Array.isArray(fromVal)) {
 			// Sync each array element individually. If array lengths are the same, sync in place; otherwise,
 			// sync to new array.


### PR DESCRIPTION
Based on Moh's stack trace, there's clearly a code path where hasOwnProperty is called off of null further down, but I couldn't come up with an example to replicate it. In any case, this should fix it.